### PR TITLE
Mint 001 deploy and mint support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ out/
 broadcast/
 
 # Ignores development broadcast logs
-!/broadcast
+broadcast/
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 

--- a/script/deployment/1_Deploy_Token.s.sol
+++ b/script/deployment/1_Deploy_Token.s.sol
@@ -35,7 +35,7 @@ contract TokenForProtocolDeployScript_1 is DeployScriptUtil {
         vm.startBroadcast(privateKey);
 
         /// switch to the config admin
-        minterAdminKey = vm.envUint("MINTER_ADMIN_KEY");
+        // minterAdminKey = vm.envUint("MINTER_ADMIN_KEY");
         minterAdminAddress = vm.envAddress("MINTER_ADMIN");
 
         /// Create ERC20 Upgradeable and Proxy 

--- a/script/deployment/2_Connect_TokenToProtocol.s.sol
+++ b/script/deployment/2_Connect_TokenToProtocol.s.sol
@@ -40,9 +40,10 @@ contract TokenForProtocolDeployScript_2 is DeployScriptUtil {
                 appManagerAddress,
                 tokenAddress
             );
-        uint256 freAppAdminKey = vm.envUint("MINTER_ADMIN_KEY");
+        // uint256 freAppAdminKey = vm.envUint("MINTER_ADMIN_KEY");
+        uint256 tokenAdminKey = vm.envUint("DEPLOYMENT_OWNER_KEY");
         vm.stopBroadcast();
-        vm.startBroadcast(freAppAdminKey);
+        vm.startBroadcast(tokenAdminKey);
         ProtocolToken(tokenAddress).connectHandlerToToken(
             address(applicationCoinHandlerDiamond)
         );

--- a/script/deployment/DeployForteTokenAndConfig.sh
+++ b/script/deployment/DeployForteTokenAndConfig.sh
@@ -1,6 +1,18 @@
+## 20250717 Separated out the verification of the Token, deployment and contract complexity caused intermittent failure using --verify --verifier in the deployment step
+
 source .env
-forge script script/deployment/1_Deploy_Token.s.sol --ffi -vvvv --rpc-url $ETH_RPC_URL --broadcast --gas-price 20 --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY
+forge script script/deployment/1_Deploy_Token.s.sol --ffi -vvvv --rpc-url $ETH_RPC_URL --broadcast --gas-price 20 --etherscan-api-key $ETHERSCAN_API_KEY
+
+# wait after the script for token tracker updates on chain (rather than using --slow)
+echo "Waiting for token tracker updates on chain to catch up (60 seconds)"
+sleep 60
+
+# pick up the TOKEN_ADDRESS set in the previous script
 source .env
+# verify the token contract
+forge verify-contract $TOKEN_ADDRESS src/token/ProtocolToken.sol:ProtocolToken --chain-id 11155111 --etherscan-api-key $ETHERSCAN_API_KEY --watch --flatten                          
+
+# connect the token to the protocol
 forge script script/deployment/2_Connect_TokenToProtocol.s.sol --ffi -vvvv --rpc-url $ETH_RPC_URL --broadcast --gas-price 20 --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY
 source .env
 forge script script/deployment/3_Setup_TokenForProtocol.s.sol --ffi -vvvv --rpc-url $ETH_RPC_URL --broadcast --gas-price 20 --verify --verifier etherscan --etherscan-api-key $ETHERSCAN_API_KEY


### PR DESCRIPTION
Minor changes to the scripts used for deployment and mint. 

The changes intend to

1. remove the need for the `MINTER_ADMIN_KEY` being required by the deployment scripts following the requirement that customer wallet keys cannot be shared / move outside of customer custody at any time.
2. prevent the connectHandlerToToken() call from failing and effectively disabling all the rules for the token by adding a deliberate split between deployment and verification rather than using `--verify` on for the ProtocolToken and proxy deployment. This includes  an extra delay to allow etherscan to update its token trackers. 